### PR TITLE
Sortitions have a reference.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decidim-module-sortitions (0.1.1)
+    decidim-module-sortitions (0.1.3)
       decidim-admin (~> 0.8.3)
       decidim-core (~> 0.8.3)
       rails (~> 5.1.4)

--- a/app/models/decidim/module/sortitions/sortition.rb
+++ b/app/models/decidim/module/sortitions/sortition.rb
@@ -7,6 +7,7 @@ module Decidim
       class Sortition < ApplicationRecord
         include Decidim::HasCategory
         include Decidim::HasFeature
+        include Decidim::HasReference
 
         feature_manifest_name "sortitions"
 

--- a/app/models/decidim/module/sortitions/sortition.rb
+++ b/app/models/decidim/module/sortitions/sortition.rb
@@ -15,6 +15,8 @@ module Decidim
                    foreign_key: "decidim_proposals_feature_id",
                    class_name: "Decidim::Feature"
 
+        before_validation :initialize_reference
+
         def proposals
           Decidim::Proposals::Proposal.where(id: selected_proposals)
         end
@@ -29,6 +31,12 @@ module Decidim
 
         def seed
           request_timestamp.to_i * dice
+        end
+
+        private
+
+        def initialize_reference
+          self[:reference] ||= calculate_reference
         end
       end
     end

--- a/app/views/decidim/module/sortitions/sortitions/index.html.erb
+++ b/app/views/decidim/module/sortitions/sortitions/index.html.erb
@@ -1,13 +1,18 @@
-<div class="row column">
-  <div class="title-action">
-    <h2 class="title-action__title section-heading"><%=t ".additional_info" %></h2>
+<div class="row">
+  <div class="columns section view-side mediumlarge-4 mediumlarge-push-8 large-3 large-push-9">
+    <%= feature_reference(sortition) %>
   </div>
-  <div class="section">
-    <%= sanitize translated_attribute sortition.additional_info %>
+  <div class="columns mediumlarge-8 mediumlarge-pull-4">
+    <div class="title-action">
+      <h2 class="title-action__title section-heading"><%=t ".additional_info" %></h2>
+    </div>
+    <div class="section">
+      <%= sanitize translated_attribute sortition.additional_info %>
+    </div>
   </div>
 </div>
 
-<div class="row column">
+<div class="row column">    
   <div class="title-action">
     <h2 class="title-action__title section-heading"><%=t ".witnesses" %></h2>
   </div>

--- a/db/migrate/20180102101128_add_reference_to_sortitions.rb
+++ b/db/migrate/20180102101128_add_reference_to_sortitions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class AddReferenceToSortitions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :decidim_module_sortitions_sortitions, :reference, :string
+
+    Decidim::Module::Sortitions::Sortition.find_each do |sortition|
+      sortition.update(reference: Decidim.resource_reference_generator.call(sortition, sortition.feature))
+    end
+
+    change_column_null :decidim_module_sortitions_sortitions, :reference, false
+  end
+end

--- a/lib/decidim/module/sortitions/version.rb
+++ b/lib/decidim/module/sortitions/version.rb
@@ -3,7 +3,7 @@
 module Decidim
   module Module
     module Sortitions
-      VERSION = "0.1.2"
+      VERSION = "0.1.3"
     end
   end
 end


### PR DESCRIPTION
#### :tophat: What? Why?
Sortition model now includes the HasReference module. The public view shows the sortition reference.

#### :pushpin: Related Issues
- Fixes #15 
